### PR TITLE
Demo on Testing Pipeline Changes

### DIFF
--- a/pipelines/container-build.yaml
+++ b/pipelines/container-build.yaml
@@ -518,6 +518,7 @@ spec:
     - name: ADDITIONAL_TAGS
       value: 
       - $(params.additional-tags[*])
+      - arbitrary-pipeline-change
     runAfter:
     - build-image-index
     taskRef:


### PR DESCRIPTION
This is a demo PR for showing how to test pipeline changes. 

`.tekton/rhoai-konflux-tasks-pull-request.yaml` will run on PR creation, and is configured to use the current PR's updated version of `pipelines/container-build.yaml` 

It will build a new image based on the sample docker file `test-build/Dockerfile.konflux`. If the build pipeline is green, we can have a reasonable level of confidence that it won't impact our actual build pipelines.