### PR TITLE
fix: checkout branch instead of FETCH_HEAD in secure-git-push

### DIFF
--- a/stepactions/secure-git-push/0.1/secure-git-push.yaml
+++ b/stepactions/secure-git-push/0.1/secure-git-push.yaml
@@ -99,7 +99,7 @@ spec:
               git sparse-checkout init
               git sparse-checkout set "${SPARSE_FILE_PATH}"
               git fetch --filter=blob:none --depth=1 origin "${REPO_BRANCH}"
-              git checkout FETCH_HEAD
+              git checkout "${REPO_BRANCH}"
           else
               git fetch --depth=1 origin "${REPO_BRANCH}"
               git checkout "${REPO_BRANCH}"


### PR DESCRIPTION
## Summary
Fix detached HEAD state in `secure-git-push` that breaks `git pull` and `git push`.

## Problem
The partial clone fix (#241) used `git checkout FETCH_HEAD` which puts git in detached HEAD state. The `secure-git-push` script later runs `git pull` and `git push` which require being on a branch. This caused:

```
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD) state now, use
    git push origin HEAD:<name-of-remote-branch>
```

Observed in `kserve-group-test-4k7wr`.

## Fix
Change `git checkout FETCH_HEAD` to `git checkout "${REPO_BRANCH}"`. After `git fetch`, git auto-creates the local branch tracking `origin/${REPO_BRANCH}`.

## Test plan
- [ ] Trigger `/group-test` on a kserve PR and verify `git-push-artifacts` steps succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)