### PR TITLE
feat: add fallback-tag param to generate-snapshot-for-group-testing

### DIFF
--- a/konflux-tekton-tasks/generate-snapshot-for-group-testing/0.1/generate-snapshot-for-group-testing.yaml
+++ b/konflux-tekton-tasks/generate-snapshot-for-group-testing/0.1/generate-snapshot-for-group-testing.yaml
@@ -11,6 +11,10 @@ spec:
   params:
     - name: COMPONENTS
       description: List of components in the group
+    - name: fallback-tag
+      type: string
+      default: odh-stable
+      description: Quay tag when PR image is missing
   results:
   - description: Snapshot json string
     name: SNAPSHOT
@@ -21,6 +25,8 @@ spec:
       env:
         - name: COMPONENTS
           value: $(params.COMPONENTS)
+        - name: FALLBACK_TAG
+          value: $(params.fallback-tag)
         - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
           value: $(workspaces.basic-auth.bound)
         - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
@@ -44,7 +50,6 @@ spec:
         while IFS= read -r row; do
             # Tag to search for
             TAG="odh-pr-${PR_NUMBER}"
-            FALLBACK_TAG="odh-stable"
         
             # Decode the base64 encoded row
             component=$(echo "$row" | base64 -d | jq -r '.key')


### PR DESCRIPTION
[RHOAIENG-57512]
### Summary
The generate-snapshot-for-group-testing task always fell back to the odh-stable tag when a PR image was missing. This change exposes that value as a Task parameter so callers (e.g. central pipelines) can override it without editing the task.

### Changes
Add spec.params.fallback-tag (string, default odh-stable, short description for Quay tag when PR image is missing).
Set FALLBACK_TAG in the generate-snapshot step env from $(params.fallback-tag) and remove the hardcoded assignment in the script.

### Behavior
Default remains odh-stable when the param is not set.
No change to PR tag detection (odh-pr-<number>) or the rest of the snapshot logic.