### PR TITLE
add support for prefetching helm charts

### DIFF
--- a/konflux-tekton-tasks/prefetch-operand-manifests-oci-ta/0.1/prefetch-operand-manifests-oci-ta.yaml
+++ b/konflux-tekton-tasks/prefetch-operand-manifests-oci-ta/0.1/prefetch-operand-manifests-oci-ta.yaml
@@ -178,10 +178,12 @@ spec:
         
         echo "*************** Prefetching manifests ********************"
           PREFETCHED_MANIFEST_DIR_PATH="/var/workdir/cachi2/prefetched-manifests"
+          PREFETCHED_CHARTS_DIR_PATH="/var/workdir/cachi2/prefetched-charts"
           MANIFEST_CONFIG_PATH=/var/workdir/source/build/manifests-config.yaml
 
           # Create fresh directories
           mkdir -p "$PREFETCHED_MANIFEST_DIR_PATH"
+          mkdir -p "$PREFETCHED_CHARTS_DIR_PATH"
           echo "# general cachi2 config" > /var/workdir/cachi2/cachi2.env
           mkdir -p manifests
           cd manifests
@@ -218,16 +220,25 @@ spec:
 
                   src=$(value="$value" yq '.map[strenv(value)]["src"]' ${MANIFEST_CONFIG_PATH})
                   dest=$(value="$value" yq '.map[strenv(value)]["dest"]' ${MANIFEST_CONFIG_PATH})
-                  
+                  entry_type=$(value="$value" yq '.map[strenv(value)]["type"] // "manifest"' ${MANIFEST_CONFIG_PATH})
+
+                  # Route to the correct output directory based on type
+                  if [[ "$entry_type" == "chart" ]]; then
+                    PREFETCHED_DIR_PATH="${PREFETCHED_CHARTS_DIR_PATH}"
+                  else
+                    PREFETCHED_DIR_PATH="${PREFETCHED_MANIFEST_DIR_PATH}"
+                  fi
+
                   echo "component = $component"
                   echo "git_url = $git_url"
                   echo "git_commit = $git_commit"
                   echo "src = $src"
                   echo "dest = $dest"
-          
+                  echo "type = $entry_type"
+
                   mkdir -p $component
                   cd $component
-          
+
                   # git config --global init.defaultBranch ${BRANCH}
                   git init
                   git remote add origin $git_url
@@ -236,11 +247,11 @@ spec:
                   echo "$src" >> .git/info/sparse-checkout
                   git fetch --depth=1 origin $git_commit
                   git checkout $git_commit
-          
+
                   cd ../
                   echo "current dir = $(pwd)"
-                  
-                  dest_dir_path=${PREFETCHED_MANIFEST_DIR_PATH}/$dest
+
+                  dest_dir_path=${PREFETCHED_DIR_PATH}/$dest
                   mkdir -p ${dest_dir_path}
 
                   cp -r $component/$src/* ${dest_dir_path}
@@ -248,7 +259,79 @@ spec:
               fi
           done < <(yq e '.map | keys' ${MANIFEST_CONFIG_PATH} )
           
+          echo "=== Prefetched Manifests ==="
           cd ${PREFETCHED_MANIFEST_DIR_PATH}
+        ls -l
+
+        echo "*************** Prefetching charts ********************"
+          CHARTS_CONFIG_PATH=/var/workdir/source/build/charts-config.yaml
+
+          if [ -f "$CHARTS_CONFIG_PATH" ]; then
+            cd /var/workdir
+            mkdir -p charts
+            cd charts
+            while IFS= read -r value;
+            do
+                value=${value/- /}
+                component=$value
+
+                # Skip empty keys
+                [[ -z "$component" ]] && continue
+
+                echo "=============================================================="
+                echo "Fetching Chart for component: $component"
+                echo "=============================================================="
+                if [[ -n $component ]]
+                then
+                    git_url=$(value="$value" yq '.map[strenv(value)]["git.url"]' ${CHARTS_CONFIG_PATH})
+                    git_commit=$(value="$value" yq '.map[strenv(value)]["git.commit"]' ${CHARTS_CONFIG_PATH})
+                    ref_type=$(value="$value" yq '.map[strenv(value)]["ref_type"]' ${CHARTS_CONFIG_PATH})
+                    BRANCH=$(value="$value" yq '.map[strenv(value)]["branch"]' ${CHARTS_CONFIG_PATH})
+
+                    # If ref_type is branch, resolve the actual commit SHA
+                    if [[ "$ref_type" == "branch" ]]; then
+                      git_commit=$(git ls-remote "$git_url" "refs/heads/$BRANCH" | awk '{print $1}')
+                      echo "Resolved git.commit for branch '$BRANCH' to commit SHA $git_commit"
+
+                      value="$value" git_commit="$git_commit" yq -i eval '.map[strenv(value)]["git.commit"] = strenv(git_commit)' ${CHARTS_CONFIG_PATH}
+                    fi
+
+                    src=$(value="$value" yq '.map[strenv(value)]["src"]' ${CHARTS_CONFIG_PATH})
+                    dest=$(value="$value" yq '.map[strenv(value)]["dest"]' ${CHARTS_CONFIG_PATH})
+
+                    echo "component = $component"
+                    echo "git_url = $git_url"
+                    echo "git_commit = $git_commit"
+                    echo "src = $src"
+                    echo "dest = $dest"
+
+                    mkdir -p $component
+                    cd $component
+
+                    git init
+                    git remote add origin $git_url
+                    git config core.sparseCheckout true
+                    git config core.sparseCheckoutCone false
+                    echo "$src" >> .git/info/sparse-checkout
+                    git fetch --depth=1 origin $git_commit
+                    git checkout $git_commit
+
+                    cd ../
+                    echo "current dir = $(pwd)"
+
+                    dest_dir_path=${PREFETCHED_CHARTS_DIR_PATH}/$dest
+                    mkdir -p ${dest_dir_path}
+
+                    cp -r $component/$src/* ${dest_dir_path}
+                    echo ""
+                fi
+            done < <(yq e '.map | keys' ${CHARTS_CONFIG_PATH} )
+          else
+            echo "No charts-config.yaml found at ${CHARTS_CONFIG_PATH}, skipping charts prefetch"
+          fi
+
+          echo "=== Prefetched Charts ==="
+          cd ${PREFETCHED_CHARTS_DIR_PATH}
         ls -l
         
 


### PR DESCRIPTION
## Summary

Add Helm chart prefetching support to the `prefetch-operand-manifests-oci-ta` task, bringing it to parity with the downstream GitHub Actions operator-processor workflow.

Changes have been verfied downstream (see https://github.com/red-hat-data-services/rhods-operator/commit/9c0225bd938f3f4cf2a664c20a66d1f4ee819fe4) and midstream (https://github.com/opendatahub-io/opendatahub-operator/pull/3763/checks?check_run_id=85367798065)

## What changed

### 1. `type: chart` routing in manifest loop
Entries in `manifests-config.yaml` with `type: chart` are now routed to `prefetched-charts/` instead of `prefetched-manifests/`. Entries without a `type` field default to `"manifest"`, preserving backward compatibility.

### 2. `charts-config.yaml` prefetch loop
A new loop after the manifest loop reads `build/charts-config.yaml` (if present) and fetches chart entries into `prefetched-charts/` using the same sparse-checkout pattern. Supports per-entry `branch` field and `ref_type: branch` resolution. Skips gracefully if the file doesn't exist.

### 3. Output directory setup
`prefetched-charts/` is created alongside `prefetched-manifests/` under `/var/workdir/cachi2/`. Both directories are packaged into the `CACHI2_ARTIFACT` automatically since `create-trusted-artifact` already archives all of `/var/workdir/cachi2`.

## Backward compatibility

- No new task params, results, or interface changes
- Entries without `type` field default to `"manifest"` — existing behavior unchanged
- Missing `charts-config.yaml` is handled gracefully with a skip log message
- `prefetched-charts/` directory is empty but harmless when no charts are configured

## Related changes

- **`opendatahub-operator`** — `Dockerfiles/rhoai.Dockerfile` updated to copy `prefetched-charts/` into `/opt/charts/` during CI builds (https://github.com/opendatahub-io/opendatahub-operator/pull/3763)
- **`rhods-operator`** — `.github/workflows/operator-processor.yaml` updated with matching `type: chart` routing and cleanup coordination between manifest and chart steps (https://github.com/red-hat-data-services/rhods-operator/pull/34098)
