### PR TITLE
fix: only delete PR comments from the same ITS pipeline

### DIFF
--- a/stepactions/pull-request-comment/0.1/pull-request-comment.yaml
+++ b/stepactions/pull-request-comment/0.1/pull-request-comment.yaml
@@ -132,8 +132,15 @@ spec:
     COMMENTS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
         "https://api.github.com/repos/$GIT_ORG/$GIT_REPO/issues/$PR_NUMBER/comments")
 
-    # Find and delete any existing comments by the authenticated user
-    COMMENT_IDS=$(echo "$COMMENTS" | jq -r --arg USER_LOGIN "$USER_LOGIN" '.[] | select(.user.login == $USER_LOGIN) | .id')
+    # Derive the pipeline name prefix by stripping the random suffix
+    # so each ITS only deletes its own previous comments, not comments from other pipelines
+    PIPELINE_PREFIX=$(echo "$TEST_NAME" | sed 's/-[a-z0-9]*$//')
+    PIPELINE_MARKER="<!-- pipeline: ${PIPELINE_PREFIX} -->"
+    echo "[INFO] Filtering comments by pipeline marker: $PIPELINE_MARKER"
+
+    # Find and delete existing comments by the authenticated user for this pipeline only
+    # Uses an HTML comment marker embedded in the PR comment body for reliable matching
+    COMMENT_IDS=$(echo "$COMMENTS" | jq -r --arg USER_LOGIN "$USER_LOGIN" --arg MARKER "$PIPELINE_MARKER" '.[] | select(.user.login == $USER_LOGIN and (.body | contains($MARKER))) | .id')
     for COMMENT_ID in $COMMENT_IDS; do
         DELETE_RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             -X DELETE \
@@ -181,6 +188,7 @@ spec:
     echo "PR_AUTHOR=$PR_AUTHOR"
     
     PR_COMMENT=$(cat <<EOF
+    ${PIPELINE_MARKER}
     @${PR_AUTHOR}: The following test has ${PIPELINE_RUN_AGGREGATE_STATUS}:
     ### OCI Artifact Browser URL
     ${ARTIFACT_BROWSER_URL}


### PR DESCRIPTION
## Summary
- When multiple ITS pipelines run concurrently on the same PR (e.g. unit tests and e2e tests), each pipeline's PR comment step was deleting ALL bot comments before posting its own, causing only the last pipeline to finish to have a visible comment
- Derives the pipeline name prefix from the PipelineRun name (strips the random suffix) and only deletes comments whose body contains that prefix
- Each ITS now keeps its own comment without interfering with other pipelines

## Test plan
- [x] Verified on [trainer-operator PR #30](https://github.com/opendatahub-io/trainer-operator/pull/30) — both unit test and e2e test comments coexist

🤖 Generated with [Claude Code](https://claude.com/claude-code)