### PR TITLE
feat: parse JUnit XML and show test results in PR comments

### DIFF
--- a/stepactions/pull-request-comment/0.1/pull-request-comment.yaml
+++ b/stepactions/pull-request-comment/0.1/pull-request-comment.yaml
@@ -87,6 +87,8 @@ spec:
       value: "$(params.pipeline-aggregate-status)"
     - name: ARTIFACT_BROWSER_URL
       value: "$(params.artifact-browser-url)"
+    - name: JUNIT_REPORT_NAME
+      value: "$(params.junit-report-name)"
     - name: GITHUB_TOKEN
       valueFrom:
         secretKeyRef:
@@ -164,6 +166,54 @@ spec:
     # Store the content of the test results analysis (from a previous step) in a variable
     TEST_RESULTS_ANALYSIS=$(cat analysis.md || echo "\<not enabled\>")
 
+    # Parse JUnit XML to generate a test results section for the PR comment
+    TEST_RESULTS_SECTION=""
+    if [ ! -f "${JUNIT_REPORT_NAME}" ]; then
+        echo "[INFO] No JUnit report found at ${JUNIT_REPORT_NAME}, skipping test results"
+    elif ! xmllint --noout "${JUNIT_REPORT_NAME}" 2>/dev/null; then
+        echo "[WARN] JUnit report at ${JUNIT_REPORT_NAME} is malformed XML, skipping test results"
+    else
+        TOTAL=$(xmllint --xpath 'count(//testcase)' "${JUNIT_REPORT_NAME}" 2>/dev/null || echo "0")
+        if [ "$TOTAL" -gt 0 ]; then
+            TABLE_ROWS=""
+            PASS_COUNT=0
+            FAIL_COUNT=0
+            SKIP_COUNT=0
+            i=1
+            while [ "$i" -le "$TOTAL" ]; do
+                TC_NAME=$(xmllint --xpath "string((//testcase)[$i]/@name)" "${JUNIT_REPORT_NAME}" 2>/dev/null)
+                TC_TIME=$(xmllint --xpath "string((//testcase)[$i]/@time)" "${JUNIT_REPORT_NAME}" 2>/dev/null)
+                HAS_FAILURE=$(xmllint --xpath "count((//testcase)[$i]/failure) + count((//testcase)[$i]/error)" "${JUNIT_REPORT_NAME}" 2>/dev/null || echo "0")
+                HAS_SKIP=$(xmllint --xpath "count((//testcase)[$i]/skipped)" "${JUNIT_REPORT_NAME}" 2>/dev/null || echo "0")
+                if [ "$HAS_FAILURE" -gt 0 ]; then
+                    TABLE_ROWS="${TABLE_ROWS}| \`${TC_NAME}\` | :x: FAIL | ${TC_TIME}s |
+    "
+                    FAIL_COUNT=$((FAIL_COUNT + 1))
+                elif [ "$HAS_SKIP" -gt 0 ]; then
+                    TABLE_ROWS="${TABLE_ROWS}| \`${TC_NAME}\` | :next_track_button: SKIP | ${TC_TIME}s |
+    "
+                    SKIP_COUNT=$((SKIP_COUNT + 1))
+                else
+                    TABLE_ROWS="${TABLE_ROWS}| \`${TC_NAME}\` | :white_check_mark: PASS | ${TC_TIME}s |
+    "
+                    PASS_COUNT=$((PASS_COUNT + 1))
+                fi
+                i=$((i + 1))
+            done
+            TEST_RESULTS_SECTION="### Test Results
+    **${PASS_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped**
+
+    <details>
+    <summary>View test details</summary>
+
+    | Test | Result | Duration |
+    |------|--------|----------|
+    ${TABLE_ROWS}
+    </details>
+    "
+        fi
+    fi
+
     # Generate artifact browser link if URL is provided
     # ARTIFACT_BROWSER_URL=$(echo "\<not enabled\>")
     if [ -n "${ARTIFACT_BROWSER_URL}" ]; then
@@ -182,6 +232,7 @@ spec:
     
     PR_COMMENT=$(cat <<EOF
     @${PR_AUTHOR}: The following test has ${PIPELINE_RUN_AGGREGATE_STATUS}:
+    ${TEST_RESULTS_SECTION}
     ### OCI Artifact Browser URL
     ${ARTIFACT_BROWSER_URL}
     ### Inspecting Test Artifacts Manually


### PR DESCRIPTION
## Summary
- Parses JUnit XML reports to generate a per-test pass/fail/skip results table in PR comments
- Results are shown in a collapsible `<details>` section — summary line (e.g. **2 passed, 1 failed, 0 skipped**) is always visible, the full table expands on click
- The `junit-report-name` param (defaulting to `junit.xml`) controls which file to parse; pipelines can pass a full path to the JUnit file

## Test plan
- [x] Verified on [trainer-operator PR #30](https://github.com/opendatahub-io/trainer-operator/pull/30) — both unit test and e2e test results are displayed with collapsible details

🤖 Generated with [Claude Code](https://claude.com/claude-code)