### PR TITLE
fix(rhoai-init): rewrite image-namespace from rhoai-private to rhoai

### DIFF
--- a/konflux-tekton-tasks/rhoai-init/0.1/rhoai-init.yaml
+++ b/konflux-tekton-tasks/rhoai-init/0.1/rhoai-init.yaml
@@ -249,6 +249,8 @@ spec:
 
       if [[ "$image_namespace" == "rhoai-private" ]]; then
         echo "Embargoed build target detected. Not sending slack message"
+        # Prod delivery repo is "rhoai" for both embargoed and non-embargoed builds
+        echo -n "rhoai" > "$(results.image-namespace.path)"
         echo -n "true" > "$(results.skip-slack-message.path)"
         exit 0
       fi


### PR DESCRIPTION
## Summary

- When `image-namespace` resolves to `rhoai-private`, overwrite the result to `rhoai` so downstream tasks see the correct prod delivery repo
- The prod delivery repo is `rhoai` for both embargoed and non-embargoed builds

Resolves: [RHOAIENG-81973](https://redhat.atlassian.net/browse/RHOAIENG-81973)

## Test plan

- [ ] Trigger an embargo build and verify the `image-namespace` result is `rhoai`, not `rhoai-private`
- [ ] Verify non-embargo builds are unaffected
- [ ] Verify Slack message is still skipped for embargo builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)